### PR TITLE
fix direct field reference in forms.py

### DIFF
--- a/genfkadmin/forms.py
+++ b/genfkadmin/forms.py
@@ -30,6 +30,7 @@ class GenericFKModelForm(forms.ModelForm):
                     field_name=field.name
                 )
                 self.generic_fields[generic_field_name] = {
+                    "original_field_name": field.name,
                     "ct_field": field.ct_field,
                     "fk_field": field.fk_field,
                 }
@@ -48,7 +49,10 @@ class GenericFKModelForm(forms.ModelForm):
         # generate the initial value for any of the generic fields so that
         # the correct choice is auto selected
         if field_name in self.generic_fields:
-            target_instance = self.instance.content_object
+            target_instance = getattr(
+                self.instance,
+                self.generic_fields[field_name]["original_field_name"],
+            )
             if target_instance:
                 return FIELD_ID_FORMAT.format(
                     app_label=target_instance._meta.app_label,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,8 +109,8 @@ def marketing_materials():
     sms3 = SMSDeliveryMechanismFactory(customer=c2)
     sms4 = SMSDeliveryMechanismFactory(customer=c2)
 
-    m1 = MarketingMaterialFactory(customer=c1, content_object=sms1)
-    m2 = MarketingMaterialFactory(customer=c2, content_object=e3)
+    m1 = MarketingMaterialFactory(customer=c1, delivery_method=sms1)
+    m2 = MarketingMaterialFactory(customer=c2, delivery_method=e3)
 
     return {
         "customer": {"c1": c1, "c2": c2},

--- a/tests/models.py
+++ b/tests/models.py
@@ -70,7 +70,7 @@ class MarketingMaterial(models.Model):
 
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveBigIntegerField()
-    content_object = GenericForeignKey("content_type", "object_id")
+    delivery_method = GenericForeignKey("content_type", "object_id")
 
     class Meta:
         indexes = [

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -168,7 +168,7 @@ def test_admin_partial_subclass(marketing_materials):
     ]
     actual_choices = [
         value
-        for optgroup, choices in form.fields["content_object_gfk"].choices
+        for optgroup, choices in form.fields["delivery_method_gfk"].choices
         for value, display_value in choices
     ]
     assert expected_choices == actual_choices


### PR DESCRIPTION
- I accidentally wrote `get_initial_for_field` to expect there always be a content_object field on instance
- this was wrong on two counts, 1. assuming that would be the name of the fk field, and 2. accessing the wrong value if there was more than one generic field